### PR TITLE
Fix dependency to derelict-sdl2

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
             "sourcePaths": [ "gfm/sdl2" ],
             "importPaths": [ "." ],
             "dependencies": {
-                "derelict-sdl2": ">=2.0.0",
+                "derelict-sdl2": "~2.0.0",
                 "gfm:core": "~master",
                 "gfm:math": "~master"
             }


### PR DESCRIPTION
There is currently no version tag for derelict-sdl2, only a branch named "2.0.0". This change should fix the dependency graph, although it would probably be better if a "v2.0.0" tag would be added instead.
