### PR TITLE
Fix typo in wasQuitRequested name and doc

### DIFF
--- a/sdl2/gfm/sdl2/sdl.d
+++ b/sdl2/gfm/sdl2/sdl.d
@@ -221,6 +221,8 @@ final class SDL2
             return _quitWasRequested;
         }        
 
+        deprecated alias wasQuitResquested = wasQuitRequested;
+
         /// Start text input.
         void startTextInput()
         {


### PR DESCRIPTION
Small thing that I noticed when using gfm. Easy fix.
