### PR TITLE
Fixed compilation of gfm.math.vector.{max, min}, added Box.expand

### DIFF
--- a/math/gfm/math/box.d
+++ b/math/gfm/math/box.d
@@ -227,6 +227,13 @@ align(1) struct Box(T, size_t N)
             return shrink(bound_t(space));
         }
 
+        /// Expand the box to include point.
+        Box expand(bound_t point) pure const nothrow
+        {
+          import vector = gfm.math.vector;
+          return Box(vector.min(min, point), vector.max(max, point));
+        }
+
         /// Returns: true if each dimension of the box is >= 0.
         bool isSorted() pure const nothrow
         {
@@ -307,4 +314,6 @@ unittest
     assert(c.contains(vec2i(0, 0)));
     assert(!c.contains(vec2i(1, 1)));
     assert(b.contains(b));
+    box2i d = c.expand(vec2i(3, 3));
+    assert(d.contains(vec2i(2, 2)));
 }

--- a/math/gfm/math/vector.d
+++ b/math/gfm/math/vector.d
@@ -556,6 +556,7 @@ mixin(definePostfixAliases("vec4"));
 /// Element-wise minimum.
 Vector!(T, N) min(T, size_t N)(const Vector!(T, N) a, const Vector!(T, N) b) pure nothrow
 {
+    import std.algorithm: min;
     Vector!(T, N) res = void;
     for(size_t i = 0; i < N; ++i)
         res[i] = min(a.v[i], b.v[i]);
@@ -565,6 +566,7 @@ Vector!(T, N) min(T, size_t N)(const Vector!(T, N) a, const Vector!(T, N) b) pur
 /// Element-wise maximum.
 Vector!(T, N) max(T, size_t N)(const Vector!(T, N) a, const Vector!(T, N) b) pure nothrow
 {
+    import std.algorithm: max;
     Vector!(T, N) res = void;
     for(size_t i = 0; i < N; ++i)
         res[i] = max(a.v[i], b.v[i]);


### PR DESCRIPTION
This adds `expand` to `Box`, which grows the box to include the point given.

Also, `min` and `max` in `gfm.math.vector` were failing to compile, so I fixed that.
