### PR TITLE
[sdl wrapper] Added SDL_SetWindowIcon wrapper function

### DIFF
--- a/sdl2/gfm/sdl2/window.d
+++ b/sdl2/gfm/sdl2/window.d
@@ -170,6 +170,12 @@ class SDL2Window : KeyboardListener, MouseListener
             return SDL_Point(w, h);
         }
 
+        /// See_also: $(LINK https://wiki.libsdl.org/SDL_SetWindowIcon)
+        final void setIcon(SDL2Surface icon)
+        {
+                SDL_SetWindowIcon( _window, icon.handle() );
+        }
+
         /// See_also: $(LINK http://wiki.libsdl.org/SDL_GetWindowSize)
         /// Returns: Window width in pixels.
         final int getWidth()


### PR DESCRIPTION
Pretty self explanatory. I thought this would be a nice function to have, prevents one from having to call

```
SDL_SetWindowIcon( SDL_GetWindowFromID( window.id() ) , icon.handle() );
```
