### PR TITLE
Add support for selecting SDL2 version

### DIFF
--- a/sdl2/gfm/sdl2/sdl.d
+++ b/sdl2/gfm/sdl2/sdl.d
@@ -39,17 +39,21 @@ final class SDL2
     {
         /// Load SDL2 library, redirect logging to our logger.
         /// You can pass a null logger if you don't want logging.
+        /// You can specify a minimum version of SDL2 you wish your project to support.
         /// Creating this object doesn't initialize any SDL subsystem!
+        /// Params:
+        ///     logger         = The logger to redirect logging to.
+        ///     sdl2Version    = The version of SDL2 to load. Defaults to SharedLibVersion(2, 0, 0).
         /// Throws: $(D SDL2Exception) on error.
         /// See_also: $(LINK http://wiki.libsdl.org/SDL_Init), $(D subSystemInit)
-        this(Logger logger)
+        this(Logger logger, SharedLibVersion sdl2Version = SharedLibVersion(2, 0, 3))
         {
             _logger = logger is null ? new NullLogger() : logger;
             _SDLInitialized = false;
             _SDL2LoggingRedirected = false;
             try
             {
-                DerelictSDL2.load();
+                DerelictSDL2.load(sdl2Version);
             }
             catch(DerelictException e)
             {


### PR DESCRIPTION
On a clean install of Ubuntu 15.04 I couldn't find a way to get SDL 2.0.3, other than building from sources, so I thought this would be a nice addition to the library, since other people may also run into a similar problem.

As the new parameter has a default value, I think this shouldn't be a breaking change. I chose version __2.0.0__ since, AFAICS, GFM doesn't require stuff from latter versions (please correct me, if I am wrong).