### PR TITLE
Explicit resources freeing

### DIFF
--- a/opengl/gfm/opengl/program.d
+++ b/opengl/gfm/opengl/program.d
@@ -183,6 +183,9 @@ final class GLProgram
                 }
             }
             this(gl, shaders);
+            
+            foreach(shader; shaders)
+              shader.close();
         }
 
         /// Ditto, except with lines in a single string.


### PR DESCRIPTION
It improves resource management. For example I try to build a gfm example with de_window library instead of sdl2, de_window doesn't allow to allocate a window on stack and allocating a window on heap causes segfaults during garbage collection (in GLShader dtor). This PR prevents segfault, because shaders are destroyed explicitly.