### PR TITLE
Add ability to assign vector from castable array

### DIFF
--- a/math/gfm/math/vector.d
+++ b/math/gfm/math/vector.d
@@ -157,7 +157,7 @@ nothrow:
         }
         
         /// Assign from castable static array.
-        @nogc ref Vector opAssign(U)(U arr) pure nothrow if ((isStaticArray!(U) && is(typeof(cast(T)arr[0])) && (arr.length == N)))
+        @nogc ref Vector opAssign(U)(U arr) pure nothrow if ((isStaticArray!(U) && !is(typeof(arr[0]) : T) && is(typeof(cast(T)arr[0])) && (arr.length == N)))
         {
             mixin(generateLoopCode!("v[@] = cast(T)arr[@];", N)());
             return this;
@@ -173,7 +173,7 @@ nothrow:
         }
         
         /// Assign from castable dynamic array.
-        @nogc ref Vector opAssign(U)(U arr) pure nothrow if (isDynamicArray!(U) && is(typeof(cast(T)arr[0])))
+        @nogc ref Vector opAssign(U)(U arr) pure nothrow if (isDynamicArray!(U) && !is(typeof(arr[0]) : T) && is(typeof(cast(T)arr[0])))
         {
             mixin(generateLoopCode!("v[@] = cast(T)arr[@];", N)());
             return this;

--- a/math/gfm/math/vector.d
+++ b/math/gfm/math/vector.d
@@ -155,6 +155,13 @@ nothrow:
             v[] = arr[];
             return this;
         }
+        
+        /// Assign from castable static array.
+        @nogc ref Vector opAssign(U)(U arr) pure nothrow if ((isStaticArray!(U) && is(typeof(cast(T)arr[0])) && (arr.length == N)))
+        {
+            mixin(generateLoopCode!("v[@] = cast(T)arr[@];", N)());
+            return this;
+        }
 
         /// Assign with a dynamic array.
         /// Size is checked in debug-mode.
@@ -162,6 +169,13 @@ nothrow:
         {
             assert(arr.length == N);
             mixin(generateLoopCode!("v[@] = arr[@];", N)());
+            return this;
+        }
+        
+        /// Assign from castable dynamic array.
+        @nogc ref Vector opAssign(U)(U arr) pure nothrow if (isDynamicArray!(U) && is(typeof(cast(T)arr[0])))
+        {
+            mixin(generateLoopCode!("v[@] = cast(T)arr[@];", N)());
             return this;
         }
 


### PR DESCRIPTION
Useful when using custom element types for Vectors.
Example: 
`Vector!(Rational, 3) v = [1, 2, 3];` 
used to require user to cast every element to Rational, now that is done implicitly if cast is possible.