### PR TITLE
Make Vector opAssign work from static arrays of compatible type.

### DIFF
--- a/math/gfm/math/vector.d
+++ b/math/gfm/math/vector.d
@@ -152,7 +152,7 @@ nothrow:
         /// Assign a Vector with a static array type.
         @nogc ref Vector opAssign(U)(U arr) pure nothrow if ((isStaticArray!(U) && isAssignable!(T, typeof(arr[0])) && (arr.length == N)))
         {
-            v[] = arr[];
+            mixin(generateLoopCode!("v[@] = arr[@];", N)());
             return this;
         }
 


### PR DESCRIPTION
If I understood correctly, if the element type of the Vector is implicitly convertible from type A, then that Vector should also be implicitly convertible from an array of type A.
My last PR implemented that for dynamic arrays, but I didn't think to check what happens with static arrays before after it was merged.
This PR implements assigning from a static array of a compatible type, not just for user types but builtin types, too.
```
long l;
int i = 1;
l = i; // Works

int[3] arr = [1, 2, 3];
Vector!(long, 3) v;
v = arr; // Used to not work, now does
```