### PR TITLE
Vector improvements

### DIFF
--- a/math/gfm/math/vector.d
+++ b/math/gfm/math/vector.d
@@ -294,7 +294,6 @@ nothrow:
             {
                 v[e] = r[e - i];
             }
-            return v[i..j];
         }
         
         /**


### PR DESCRIPTION
Added opSliceAssign, enables
```
Vector!(int, 3) v = [1, 2, 3];
v[0..2] = [4, 5];
assert(v == [4, 5, 3]);
v[1..3] = 6;
assert(v == [4, 6, 6]);
```
Unittest and documentation included.

Also generalized opAssign to use ranges, less function branching to worry about.

I did this mainly because I intend to make Matrix use a flat vector and implement range-based interfaces, which should make using it with custom types easier.