### PR TITLE
Add template constraint to math.lerp.

### DIFF
--- a/math/gfm/math/funcs.d
+++ b/math/gfm/math/funcs.d
@@ -33,6 +33,7 @@ else version( D_InlineAsm_X86_64 )
 
 /// Linear interpolation, akin to GLSL's mix.
 @nogc S lerp(S, T)(S a, S b, T t) pure nothrow
+  if (is(typeof(t * b + (1 - t) * a) : S))
 {
     return t * b + (1 - t) * a;
 }


### PR DESCRIPTION
This prevents math.lerp from conflicting with an otherwise unrelated
user-defined lerp.

For example, suppose a user wants to define lerp for colors:

```
struct Color { float r, g, b; }

auto lerp(T)(Color c1, Color c2, T f) {
  Color c;
  c.r = math.lerp(c1.r, c2.r, f);
  c.g = math.lerp(c1.g, c2.g, f);
  c.b = math.lerp(c1.b, c2.b, f);
  return c;
}
```

This would have conflicted with gfm.math.lerp, which wouldn't work on
Color as it doesn't support the necessary operations (e.g. opBinary!"+").
With the template constraint, both lerp functions can coexist.