### PR TITLE
Nicer error message when instantiating wideint with non-power-of-2 bits.

### DIFF
--- a/math/gfm/math/wideint.d
+++ b/math/gfm/math/wideint.d
@@ -39,8 +39,8 @@ alias uwideint!256 uint256;
 
 /// Use this template to get an arbitrary sized integer type.
 private template integer(bool signed, int bits)
+    if ((bits & (bits - 1)) == 0)
 {
-    static assert((bits & (bits - 1)) == 0); // bits must be a power of 2
 
     // forward to native type for lower numbers of bits
     static if (bits == 8)
@@ -75,6 +75,12 @@ private template integer(bool signed, int bits)
     {
         alias wideIntImpl!(signed, bits) integer;
     }
+}
+
+private template integer(bool signed, int bits)
+    if ((bits & (bits - 1)) != 0)
+{
+    static assert(0, "wide integer bits must be power of 2");
 }
 
 /// Recursive 2^n integer implementation.

--- a/math/gfm/math/wideint.d
+++ b/math/gfm/math/wideint.d
@@ -80,7 +80,7 @@ private template integer(bool signed, int bits)
 private template integer(bool signed, int bits)
     if ((bits & (bits - 1)) != 0)
 {
-    static assert(0, "wide integer bits must be power of 2");
+    static assert(0, "wide integer bits must be a power of 2");
 }
 
 /// Recursive 2^n integer implementation.


### PR DESCRIPTION
I tried modifying the existing static assert, but that didn't stop the compiler from spewing all kinds of messy-looking errors (probably due to the recursive nature of the template). This is the nicest way I found that gives a concise, helpful error message.