### PR TITLE
Implement wideint literals

### DIFF
--- a/math/gfm/math/wideint.d
+++ b/math/gfm/math/wideint.d
@@ -116,10 +116,15 @@ struct wideIntImpl(bool signed, int bits)
 
     /// Construct from compile-time digit string.
     ///
+    /// Both decimal and hex digit strings are supported.
+    ///
     /// Example:
     /// ----
     /// auto x = int128.literal!"20_000_000_000_000_000_001";
     /// assert((x >>> 1) == 0x8AC7_2304_89E8_0000);
+    ///
+    /// auto y = int126.literal!"0x1_158E_4609_13D0_0001";
+    /// assert(y == x);
     /// ----
     template literal(string digits)
     {

--- a/math/gfm/math/wideint.d
+++ b/math/gfm/math/wideint.d
@@ -125,7 +125,7 @@ struct wideIntImpl(bool signed, int bits)
     {
         static bool isValidDigitString(string digits)
         {
-            import std.algorithm.searching : startsWith;
+            import std.algorithm : startsWith;
             import std.ascii : isDigit;
 
             if (digits.startsWith("0x"))
@@ -149,7 +149,7 @@ struct wideIntImpl(bool signed, int bits)
 
         static typeof(this) impl(string digits)
         {
-            import std.algorithm.searching : startsWith;
+            import std.algorithm : startsWith;
             import std.ascii : isDigit;
 
             typeof(this) value = 0;


### PR DESCRIPTION
Here's my first stab at implementing wideint literals. To avoid sticky issues of whether to throw exceptions on invalid digit strings, etc., everything is parsed at compile-time. Both decimal and hex digit strings are supported. Underscores `_` are supported as separators for readability of literals. Syntax is a (tiny) bit verbose:
````
auto x = int256.literal!"0xABCD_EF01_2345";
````
but this can be easily changed to something shorter, like `lit`, or perhaps even a nested eponymous template `auto x = int256!"0x1234";`, but that might cause problems, I'm not sure.

The digit string parsing functions can probably be made available at runtime, but then you'll run into the issue of what to do if the digit string is invalid. Throwing an exception seems the most natural solution, but that conflicts with the stated goal of this module to be `nothrow`. So I'll leave this to the rest of you to fight it out. :-D