### PR TITLE
wideint.toString hex formatting consistency fixes.

### DIFF
--- a/math/gfm/math/wideint.d
+++ b/math/gfm/math/wideint.d
@@ -334,7 +334,7 @@ struct wideIntImpl(bool signed, int bits)
             for (i = maxDigits-1; tmp > 0; i--)
             {
                 assert(i > 0);
-                buf[i] = cast(Char)('0' + cast(int)(tmp % 10));
+                buf[i] = digits[cast(int)(tmp % 10)];
                 tmp /= 10;
             }
             assert(i+1 >= 0);


### PR DESCRIPTION
To conform to native int `%x` formatting conventions, `toString` should:
(1) not output a "0x" prefix (that should go in the format string);
(2) suppress unnecessary 0's to the left.

Also, fixed some wrong `assert`s that made no sense for `size_t` indices.