### PR TITLE
Avoid error in static assert in box.d.

### DIFF
--- a/math/gfm/math/box.d
+++ b/math/gfm/math/box.d
@@ -312,7 +312,7 @@ struct Box(T, int N)
             }
             else
             {
-                static assert(false, Format!("no conversion from %s to %s", U.element_t.stringof, element_t.stringof));
+                static assert(false, "no conversion from " ~ U.element_t.stringof ~ " to " ~ element_t.stringof);
             }
             return this;
         }


### PR DESCRIPTION
A static assert was trying to call the non-existant Format!. This
resulted in an unhelpful error message. Just concatenate the string
instead.

I didn't think it was worth importing `std.format` for that one error message. Maybe one day we will have `assertf` :)