### PR TITLE
SDL2 audio device wrapper

### DIFF
--- a/examples/audio/audio.d
+++ b/examples/audio/audio.d
@@ -1,0 +1,28 @@
+import std.typecons;
+
+import derelict.sdl2.sdl;
+
+
+import gfm.logger,
+       gfm.sdl2,
+       gfm.sdl2.audio;
+
+void main()
+{
+    auto log = new ConsoleLogger;
+
+    auto sdl2 = scoped!SDL2(log);
+    sdl2.subSystemInit(SDL_INIT_AUDIO);
+
+    SDL_AudioSpec spec;
+    spec.freq = 48_000;
+    spec.format = AUDIO_F32;
+    spec.channels = 1;
+    spec.samples = 4096;
+
+    auto devices = sdl2.getAudioDevices();
+
+    auto device = new SDL2AudioDevice(sdl2, devices[0], 0, &spec, null, 0);
+
+    SDL_Delay(2_000);
+}

--- a/examples/audio/dub.json
+++ b/examples/audio/dub.json
@@ -1,0 +1,13 @@
+{
+    "targetType": "executable",
+    "name": "audio",
+    "sourcePaths": [ "." ],
+    "importPaths": [ "." ],
+    "mainSourceFile": "audio.d",
+
+    "dependencies":
+    {
+        "gfm:sdl2": {"path": "../../"},
+        "gfm:logger": {"path": "../../"}
+    }
+}

--- a/sdl2/gfm/sdl2/audio.d
+++ b/sdl2/gfm/sdl2/audio.d
@@ -1,0 +1,55 @@
+module gfm.sdl2.audio;
+
+import derelict.sdl2.sdl;
+
+import gfm.sdl2.sdl;
+
+final class SDL2AudioDevice
+{
+    private
+    {
+        SDL_AudioDeviceID _id;
+    }
+
+    public
+    {
+        /++
+        See_also: $(LINK https://wiki.libsdl.org/SDL_OpenAudioDevice)
+        +/
+        this(SDL2 sdl2, const(char)[] name, int iscapture, const(SDL_AudioSpec*) desired, SDL_AudioSpec* obtained, int allowed_changes)
+        {
+            import std.string : toStringz;
+            _id = SDL_OpenAudioDevice(toStringz(name), iscapture, desired, obtained, allowed_changes);
+
+            if (_id == 0)
+            {
+                sdl2.throwSDL2Exception("SDL_OpenAudioDevice");
+            }
+        }
+
+        ~this()
+        {
+            SDL_CloseAudioDevice(_id);
+        }
+
+        nothrow @nogc
+        {
+            /++
+            Checks if this audio device is currently playing sound
+            See_also: $(D status), $(LINK https://wiki.libsdl.org/SDL_AudioStatus)
+            +/
+            bool playing()
+            {
+                return status == SDL_AUDIO_PLAYING;
+            }
+
+            /++
+            See_also: $(D playing), $(LINK https://wiki.libsdl.org/SDL_GetAudioDeviceStatus)
+            +/
+            SDL_AudioStatus status()
+            {
+                return SDL_GetAudioDeviceStatus(_id);
+            }
+        }
+    }
+}

--- a/sdl2/gfm/sdl2/sdl.d
+++ b/sdl2/gfm/sdl2/sdl.d
@@ -297,13 +297,27 @@ final class SDL2
         }
 
         /// Returns: Available SDL video drivers.
-        const(char)[][] getVideoDrivers()
+        alias getVideoDrivers = getDrivers!(SDL_GetNumVideoDrivers, SDL_GetVideoDriver);
+
+        /// Returns: Available SDL audio drivers.
+        alias getAudioDrivers = getDrivers!(SDL_GetNumAudioDrivers, SDL_GetAudioDriver);
+
+        /++
+        Returns: Available audio device names.
+        See_also: https://wiki.libsdl.org/SDL_GetAudioDeviceName
+        Bugs: SDL2 currently doesn't support recording, so it's best to
+              call this without any arguments.
+        +/
+        const(char)[][] getAudioDevices(int type = 0)
         {
-            const int numDrivers = SDL_GetNumVideoDrivers();
+            const(int) numDevices = SDL_GetNumAudioDevices(type);
+
             const(char)[][] res;
-            res.length = numDrivers;
-            for(int i = 0; i < numDrivers; ++i)
-                res[i] = fromStringz(SDL_GetVideoDriver(i));
+            foreach (i; 0..numDevices)
+            {
+                res ~= fromStringz(SDL_GetAudioDeviceName(i, type));
+            }
+
             return res;
         }
 
@@ -392,6 +406,18 @@ final class SDL2
 
         // Holds mouse state
         SDL2Mouse _mouse;
+
+        const(char)[][] getDrivers(alias numFn, alias elemFn)()
+        {
+            const(int) numDrivers = numFn();
+            const(char)[][] res;
+            res.length = numDrivers;
+            foreach (i; 0..numDrivers)
+            {
+                res[i] = fromStringz(elemFn(i));
+            }
+            return res;
+        }
 
         void onLogMessage(int category, SDL_LogPriority priority, const(char)* message)
         {


### PR DESCRIPTION
Added lightweight wrapping of SDL2 audio devices as per #151.
Also added a small example that opens the first audio device.