### PR TITLE
SDL2 audio: added play, pause, lock and unlock wrappers

### DIFF
--- a/examples/audio/audio.d
+++ b/examples/audio/audio.d
@@ -20,9 +20,25 @@ void main()
     spec.channels = 1;
     spec.samples = 4096;
 
+    // Get all available audio devices
     auto devices = sdl2.getAudioDevices();
 
+    // Open the first audio device
     auto device = new SDL2AudioDevice(sdl2, devices[0], 0, &spec, null, 0);
 
-    SDL_Delay(2_000);
+    // Play audio on the device for 1 second
+    device.play();
+    SDL_Delay(1_000);
+
+    // Lock the device
+    device.lock();
+
+    // Unlock the device after 1 second
+    SDL_Delay(1_000);
+    device.unlock();
+
+    // Pause the device
+    device.pause();
+
+    SDL_Delay(1_000);
 }

--- a/sdl2/gfm/sdl2/audio.d
+++ b/sdl2/gfm/sdl2/audio.d
@@ -35,7 +35,43 @@ final class SDL2AudioDevice
         nothrow @nogc
         {
             /++
-            Checks if this audio device is currently playing sound
+            Starts playing sound on this device
+            See_also: $(D pause), $(LINK https://wiki.libsdl.org/SDL_PauseAudioDevice)
+            +/
+            void play()
+            {
+                SDL_PauseAudioDevice(_id, 0);
+            }
+
+            /++
+            Stops playing sound on this device
+            See_also: $(D play), $(LINK https://wiki.libsdl.org/SDL_PauseAudioDevice)
+            +/
+            void pause()
+            {
+                SDL_PauseAudioDevice(_id, 1);
+            }
+
+            /++
+            Makes SDL not run the callback from $(D desired).callback.
+            See_also: $(D unlock), $(LINK https://wiki.libsdl.org/SDL_LockAudioDevice)
+            +/
+            void lock()
+            {
+                SDL_LockAudioDevice(_id);
+            }
+
+            /++
+            Makes SDL run the callback from $(D desired).callback again.
+            See_also: $(D lock), $(LINK https://wiki.libsdl.org/SDL_UnlockAudioDevice)
+            +/
+            void unlock()
+            {
+                SDL_UnlockAudioDevice(_id);
+            }
+
+            /++
+            Checks if this audio device is currently playing sound.
             See_also: $(D status), $(LINK https://wiki.libsdl.org/SDL_AudioStatus)
             +/
             bool playing()


### PR DESCRIPTION
Also updated the example to use those functions.