### PR TITLE
Make geometric metaprogramming easier

### DIFF
--- a/math/gfm/math/box.d
+++ b/math/gfm/math/box.d
@@ -395,3 +395,14 @@ unittest
 
     assert(box2i.rectangle(1, 2, 3, 4) == box2i(1, 2, 4, 6));
 }
+
+/// True if `T` is a kind of Box
+enum isBox(T) = is(T : Box!U, U...);
+
+unittest
+{
+    static assert( isBox!box2f);
+    static assert( isBox!box3d);
+    static assert( isBox!(Box!(real, 2)));
+    static assert(!isBox!vec2f);
+}

--- a/math/gfm/math/box.d
+++ b/math/gfm/math/box.d
@@ -406,3 +406,13 @@ unittest
     static assert( isBox!(Box!(real, 2)));
     static assert(!isBox!vec2f);
 }
+
+/// Get the numeric type used to measure a box's dimensions.
+alias DimensionType(T : Box!U, U...) = U[0];
+
+///
+unittest
+{
+    static assert(is(DimensionType!box2f == float));
+    static assert(is(DimensionType!box3d == double));
+}

--- a/math/gfm/math/shapes.d
+++ b/math/gfm/math/shapes.d
@@ -439,6 +439,30 @@ enum isPlane(T) = is(T : Plane!U, U);
 /// True if `T` is a kind of Plane
 enum isFrustum(T) = is(T : Frustum!U, U);
 
+/// True if `T` is a kind of 2 dimensional Segment
+enum isSegment2D(T) = is(T : Segment!(U, 2), U);
+
+/// True if `T` is a kind of 2 dimensional Triangle
+enum isTriangle2D(T) = is(T : Triangle!(U, 2), U);
+
+/// True if `T` is a kind of 2 dimensional Sphere
+enum isSphere2D(T) = is(T : Sphere!(U, 2), U);
+
+/// True if `T` is a kind of 2 dimensional Ray
+enum isRay2D(T) = is(T : Ray!(U, 2), U);
+
+/// True if `T` is a kind of 3 dimensional Segment
+enum isSegment3D(T) = is(T : Segment!(U, 3), U);
+
+/// True if `T` is a kind of 3 dimensional Triangle
+enum isTriangle3D(T) = is(T : Triangle!(U, 3), U);
+
+/// True if `T` is a kind of 3 dimensional Sphere
+enum isSphere3D(T) = is(T : Sphere!(U, 3), U);
+
+/// True if `T` is a kind of 3 dimensional Ray
+enum isRay3D(T) = is(T : Ray!(U, 3), U);
+
 unittest
 {
     enum ShapeType
@@ -451,7 +475,7 @@ unittest
         frustum
     }
 
-    void test(T, ShapeType type)()
+    void test(T, ShapeType type, int dim)()
     {
         with (ShapeType)
         {
@@ -461,21 +485,32 @@ unittest
             static assert(isRay!T      == (type == ray     ));
             static assert(isPlane!T    == (type == plane   ));
             static assert(isFrustum!T  == (type == frustum ));
+
+            static assert(isSegment2D!T  == (type == segment  && dim == 2));
+            static assert(isTriangle2D!T == (type == triangle && dim == 2));
+            static assert(isSphere2D!T   == (type == sphere   && dim == 2));
+            static assert(isRay2D!T      == (type == ray      && dim == 2));
+
+            static assert(isSegment3D!T  == (type == segment  && dim == 3));
+            static assert(isTriangle3D!T == (type == triangle && dim == 3));
+            static assert(isSphere3D!T   == (type == sphere   && dim == 3));
+            static assert(isRay3D!T      == (type == ray      && dim == 3));
         }
     }
 
     with (ShapeType)
     {
-        test!(seg2f           , segment);
-        test!(seg3d           , segment);
-        test!(triangle2d      , triangle);
-        test!(triangle3f      , triangle);
-        test!(Sphere!(uint, 3), sphere);
-        test!(sphere2d        , sphere);
-        test!(ray2f           , ray);
-        test!(Ray!(real, 3)   , ray);
-        test!(planed          , plane);
-        test!(Plane!float     , plane);
-        test!(Frustum!double  , frustum);
+        //    test case         type      #dimensions
+        test!(seg2f           , segment , 2);
+        test!(seg3d           , segment , 3);
+        test!(triangle2d      , triangle, 2);
+        test!(triangle3f      , triangle, 3);
+        test!(sphere2d        , sphere  , 2);
+        test!(Sphere!(uint, 3), sphere  , 3);
+        test!(ray2f           , ray     , 2);
+        test!(Ray!(real, 3)   , ray     , 3);
+        test!(planed          , plane   , 0); // ignore dimension (always 3D)
+        test!(Plane!float     , plane   , 0);
+        test!(Frustum!double  , frustum , 0);
     }
 }

--- a/math/gfm/math/shapes.d
+++ b/math/gfm/math/shapes.d
@@ -420,3 +420,62 @@ unittest
     Frustum!double frust;
     planed pl;
 }
+
+/// True if `T` is a kind of Segment
+enum isSegment(T) = is(T : Segment!U, U...);
+
+/// True if `T` is a kind of Triangle
+enum isTriangle(T) = is(T : Triangle!U, U...);
+
+/// True if `T` is a kind of Sphere
+enum isSphere(T) = is(T : Sphere!U, U...);
+
+/// True if `T` is a kind of Ray
+enum isRay(T) = is(T : Ray!U, U...);
+
+/// True if `T` is a kind of Plane
+enum isPlane(T) = is(T : Plane!U, U);
+
+/// True if `T` is a kind of Plane
+enum isFrustum(T) = is(T : Frustum!U, U);
+
+unittest
+{
+    enum ShapeType
+    {
+        segment,
+        triangle,
+        sphere,
+        ray,
+        plane,
+        frustum
+    }
+
+    void test(T, ShapeType type)()
+    {
+        with (ShapeType)
+        {
+            static assert(isSegment!T  == (type == segment ));
+            static assert(isTriangle!T == (type == triangle));
+            static assert(isSphere!T   == (type == sphere  ));
+            static assert(isRay!T      == (type == ray     ));
+            static assert(isPlane!T    == (type == plane   ));
+            static assert(isFrustum!T  == (type == frustum ));
+        }
+    }
+
+    with (ShapeType)
+    {
+        test!(seg2f           , segment);
+        test!(seg3d           , segment);
+        test!(triangle2d      , triangle);
+        test!(triangle3f      , triangle);
+        test!(Sphere!(uint, 3), sphere);
+        test!(sphere2d        , sphere);
+        test!(ray2f           , ray);
+        test!(Ray!(real, 3)   , ray);
+        test!(planed          , plane);
+        test!(Plane!float     , plane);
+        test!(Frustum!double  , frustum);
+    }
+}

--- a/math/gfm/math/shapes.d
+++ b/math/gfm/math/shapes.d
@@ -514,3 +514,27 @@ unittest
         test!(Frustum!double  , frustum , 0);
     }
 }
+
+/// Get the numeric type used to measure a shape's dimensions.
+alias DimensionType(T : Segment!U, U...) = U[0];
+/// ditto
+alias DimensionType(T : Triangle!U, U...) = U[0];
+/// ditto
+alias DimensionType(T : Sphere!U, U...) = U[0];
+/// ditto
+alias DimensionType(T : Ray!U, U...) = U[0];
+/// ditto
+alias DimensionType(T : Plane!U, U) = U;
+/// ditto
+alias DimensionType(T : Frustum!U, U) = U;
+
+///
+unittest
+{
+    static assert(is(DimensionType!seg2i          == int));
+    static assert(is(DimensionType!triangle3d     == double));
+    static assert(is(DimensionType!sphere2d       == double));
+    static assert(is(DimensionType!ray3f          == float));
+    static assert(is(DimensionType!planed         == double));
+    static assert(is(DimensionType!(Frustum!real) == real));
+}

--- a/math/gfm/math/vector.d
+++ b/math/gfm/math/vector.d
@@ -492,13 +492,16 @@ nothrow:
     }
 }
 
-template isVectorInstantiation(U)
-{
-    private static void isVector(T, int N)(Vector!(T, N) x)
-    {
-    }
+/// True if `T` is some kind of `Vector`
+enum isVectorInstantiation(T) = is(T : Vector!U, U...);
 
-    enum bool isVectorInstantiation = is(typeof(isVector(U.init)));
+///
+unittest
+{
+    static assert(isVectorInstantiation!vec2f);
+    static assert(isVectorInstantiation!vec3d);
+    static assert(isVectorInstantiation!(vec4!real));
+    static assert(!isVectorInstantiation!float);
 }
 
 template vec2(T) { alias Vector!(T, 2) vec2; }

--- a/math/gfm/math/vector.d
+++ b/math/gfm/math/vector.d
@@ -504,6 +504,16 @@ unittest
     static assert(!isVectorInstantiation!float);
 }
 
+/// Get the numeric type used to measure a vectors's coordinates.
+alias DimensionType(T : Vector!U, U...) = U[0];
+
+///
+unittest
+{
+    static assert(is(DimensionType!vec2f == float));
+    static assert(is(DimensionType!vec3d == double));
+}
+
 template vec2(T) { alias Vector!(T, 2) vec2; }
 template vec3(T) { alias Vector!(T, 3) vec3; }
 template vec4(T) { alias Vector!(T, 4) vec4; }


### PR DESCRIPTION
This adds a number of templates to simplify generic code that uses gfm's geometric types.

I was doing this recently and the template constraints in my code quickly got messy, trying to deal with all the `(T, N)` possibilities of the various types (e.g. how do I constrain a template to any 2D box?).

Let me know what you think, the features are divided up by commit.

With regards to the naming, I prefer `isBox` to `isBoxInstantiation`, as it is:

1. concise and just as clear
2. similar to phobos (we have `isInputRange`, not `isInputRangeInstantiation`).

However, I didn't go back and change `isVectorInstantiation` to `isVector`, so there's a bit of inconsistency. If you do like these changes, my preference would be to add `isVector` and deprecate `isVectorInstantiation`.

Also, I considered just adding `gfm.meta` to collect all these in one place as opposed to scattering them between `box`, `vector`, and `shape`. 