### PR TITLE
Added handle getter for SDL2Renderer and SDL2Texture

### DIFF
--- a/sdl2/gfm/sdl2/renderer.d
+++ b/sdl2/gfm/sdl2/renderer.d
@@ -228,6 +228,12 @@ final class SDL2Renderer
         {
             return _info;
         }
+
+        /// Returns: SDL handle.
+        SDL_Renderer* handle()
+        {
+            return _renderer;
+        }
     }
 
     package

--- a/sdl2/gfm/sdl2/texture.d
+++ b/sdl2/gfm/sdl2/texture.d
@@ -169,6 +169,12 @@ final class SDL2Texture
                 _sdl2.throwSDL2Exception("SDL_UpdateYUVTexture");
         }
 
+        /// Returns: SDL handle.
+        SDL_Texture* handle()
+        {
+            return _handle;
+        }
+
     }
 
     package


### PR DESCRIPTION
This will aid integration with other SDL2 libraries without the need to include them in gfm.
The function name is identical to that of SDL2Surface to keep it consistent.