### PR TITLE
Fix doc comments on box and isFrustum.

### DIFF
--- a/math/gfm/math/box.d
+++ b/math/gfm/math/box.d
@@ -1,3 +1,6 @@
+/**
+  This module implements a generic axis-aligned bounding box (AABB).
+ */
 module gfm.math.box;
 
 import std.math,

--- a/math/gfm/math/shapes.d
+++ b/math/gfm/math/shapes.d
@@ -436,7 +436,7 @@ enum isRay(T) = is(T : Ray!U, U...);
 /// True if `T` is a kind of Plane
 enum isPlane(T) = is(T : Plane!U, U);
 
-/// True if `T` is a kind of Plane
+/// True if `T` is a kind of Frustum
 enum isFrustum(T) = is(T : Frustum!U, U);
 
 /// True if `T` is a kind of 2 dimensional Segment


### PR DESCRIPTION
gfm.math.box needed a doc comment at module level for docs to be
generated for it.
isFrustum was a bad copy-paste from isPlane.