### PR TITLE
Fix Plane constructor

### DIFF
--- a/math/gfm/math/shapes.d
+++ b/math/gfm/math/shapes.d
@@ -217,7 +217,7 @@ struct Plane(T) if (isFloatingPoint!T)
         @nogc this(vec4!T abcd) pure nothrow
         {
             n = vec3!T(abcd.x, abcd.y, abcd.z).normalized();
-            d = abcd.z;
+            d = abcd.w;
         }
 
         /// Create from a point and a normal.


### PR DESCRIPTION
A simple typo, I think. The unittest doesn't actually test the plane made with this constructor.