### PR TITLE
[DO NOT MERGE] Can non-vector types be usable in a vertex descriptor?

### DIFF
--- a/examples/simpleshader/simpleshader.d
+++ b/examples/simpleshader/simpleshader.d
@@ -128,15 +128,16 @@ void main()
     {
         vec3f position;
         vec2f coordinates;
+        float foo;
     }
 
     Vertex[] quad;
-    quad ~= Vertex(vec3f(-1, -1, 0), vec2f(0, 0));
-    quad ~= Vertex(vec3f(+1, -1, 0), vec2f(1, 0));
-    quad ~= Vertex(vec3f(+1, +1, 0), vec2f(1, 1));
-    quad ~= Vertex(vec3f(+1, +1, 0), vec2f(1, 1));
-    quad ~= Vertex(vec3f(-1, +1, 0), vec2f(0, 1));
-    quad ~= Vertex(vec3f(-1, -1, 0), vec2f(0, 0));
+    quad ~= Vertex(vec3f(-1, -1, 0), vec2f(0, 0), float.nan);
+    quad ~= Vertex(vec3f(+1, -1, 0), vec2f(1, 0), float.nan);
+    quad ~= Vertex(vec3f(+1, +1, 0), vec2f(1, 1), float.nan);
+    quad ~= Vertex(vec3f(+1, +1, 0), vec2f(1, 1), float.nan);
+    quad ~= Vertex(vec3f(-1, +1, 0), vec2f(0, 1), float.nan);
+    quad ~= Vertex(vec3f(-1, -1, 0), vec2f(0, 0), float.nan);
 
     auto quadVBO = scoped!GLBuffer(gl, GL_ARRAY_BUFFER, GL_STATIC_DRAW, quad[]);
 


### PR DESCRIPTION
If I added `float` field to my vertex types it fails with message:
```
core.exception.AssertError@../../opengl/gfm/opengl/vertex.d(251): Could not use float in a vertex description
```
but docs says it possible ([here](http://d-gamedev-team.github.io/gfm/gfm.opengl.vertex.html)):
```
struct MyVertex
{
    vec3f position;
    vec4f diffuse;
    float shininess;
    @Normalized vec2i uv;
    vec3f normal;
}
```
(Sorry if I asked question in wrong manner)