### PR TITLE
Use LDC/GDC intrinsic functions instead of std.math

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -42,7 +42,10 @@
         {
             "name": "math",
             "sourcePaths": [ "math/gfm/math" ],
-            "importPaths": [ "math" ]
+            "importPaths": [ "math" ],
+            "dependencies": {
+                "mir-core": "~>0.2.0"
+            }
         },
         {
             "name": "integers",

--- a/math/gfm/math/box.d
+++ b/math/gfm/math/box.d
@@ -3,10 +3,11 @@
  */
 module gfm.math.box;
 
-import std.math,
-       std.traits,
+import std.traits,
        std.conv,
        std.string;
+
+import mir.math.common;
 
 import gfm.math.vector,
        gfm.math.funcs;

--- a/math/gfm/math/funcs.d
+++ b/math/gfm/math/funcs.d
@@ -5,10 +5,12 @@
  */
 module gfm.math.funcs;
 
-import std.math,
-       std.traits,
+import std.traits,
        std.range,
-       std.math;
+       std.math : abs, acos, asin;
+
+import mir.math.common,
+       mir.math.constant;
 
 import gfm.math.vector : Vector;
 

--- a/math/gfm/math/matrix.d
+++ b/math/gfm/math/matrix.d
@@ -1,12 +1,14 @@
 /// Custom sized 2-dimension Matrices
 module gfm.math.matrix;
 
-import std.math,
-       std.typetuple,
+import std.typetuple,
        std.traits,
        std.string,
        std.typecons,
-       std.conv;
+       std.conv,
+       std.math : tan;
+
+import mir.math.common;
 
 import gfm.math.vector,
        gfm.math.shapes,

--- a/math/gfm/math/quaternion.d
+++ b/math/gfm/math/quaternion.d
@@ -1,8 +1,11 @@
 ///
 module gfm.math.quaternion;
 
-import std.math,
-       std.string;
+import std.string,
+       std.math : atan2;
+
+import mir.math.common,
+       mir.math.constant;
 
 import gfm.math.vector,
        gfm.math.matrix,

--- a/math/gfm/math/shapes.d
+++ b/math/gfm/math/shapes.d
@@ -11,8 +11,11 @@
  */
 module gfm.math.shapes;
 
-import std.math,
-       std.traits;
+import std.traits,
+       std.math : abs, approxEqual;
+
+import mir.math.common,
+       mir.math.constant;
 
 import gfm.math.vector,
        gfm.math.box;

--- a/math/gfm/math/simplerng.d
+++ b/math/gfm/math/simplerng.d
@@ -9,7 +9,10 @@
 module gfm.math.simplerng;
 
 public import std.random;
-import std.math;
+import std.math : tan;
+
+import mir.math.common,
+       mir.math.constant;
 
 /// Returns: Normal (Gaussian) random sample.
 /// See_also: Box-Muller algorithm.

--- a/math/gfm/math/vector.d
+++ b/math/gfm/math/vector.d
@@ -2,10 +2,12 @@
 module gfm.math.vector;
 
 import std.traits,
-       std.math,
        std.conv,
        std.array,
-       std.string;
+       std.string,
+       std.math : abs;
+
+import mir.math.common;
 
 import gfm.math.funcs;
 


### PR DESCRIPTION
std.math's `sin` and `cos` compute the result at real-precision then convert back to the argument type, which is the wrong speed/accuracy tradeoff for this library. LDC & GDC have other intrinsics that can be
faster than the std.math or libc equivalents due to cutting corners in ways that aren't detriments here (for instance, `llvm_sqrt` has undefined behavior for negative arguments other than -0.0).